### PR TITLE
feat(OpenAPI): Update IVizNode with parameters

### DIFF
--- a/packages/ui/src/components/OpenApi/Consumer/OpenApiConfigure.tsx
+++ b/packages/ui/src/components/OpenApi/Consumer/OpenApiConfigure.tsx
@@ -1,4 +1,3 @@
-import { Rest, RouteDefinition } from '@kaoto/camel-catalog/types';
 import {
   ActionList,
   ActionListItem,
@@ -12,46 +11,29 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
-  Card,
-  CardBody,
-  CardFooter,
-  CardTitle,
-  DropEvent,
-  FileUpload,
-  Form,
-  FormGroup,
-  HelperText,
-  HelperTextItem,
-  InputGroup,
-  Popover,
   Radio,
   SearchInput,
   Text,
   TextContent,
-  TextVariants,
   TextInput,
+  TextVariants,
   Wizard,
-  WizardHeader,
-  WizardStep,
   WizardFooterWrapper,
-  useWizardContext,
-  Title,
+  WizardStep,
+  useWizardContext
 } from '@patternfly/react-core';
-import { Table, Thead, Th, Tbody, Td, Tr } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { OpenApi, OpenApiOperation, OpenApiPath } from 'openapi-v3';
 import { FunctionComponent, useCallback, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { parse } from 'yaml';
 import { BaseVisualCamelEntity, CamelRouteVisualEntity, IVisualizationNode } from '../../../models';
 import { EntityType } from '../../../models/camel/entities';
-import { SourceSchemaType } from '../../../models/camel/source-schema-type';
-import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
-import { FlowTemplateService } from '../../../models/visualization/flows/support/flow-templates-service';
 import { EntitiesContext } from '../../../providers/entities.provider';
 import { isDefined } from '../../../utils';
-import { OpenApiSpecification } from './OpenApiSpecification';
 import PaginationTop from '../../Visualization/Pagination/PaginationTop';
+import { OpenApiSpecification } from './OpenApiSpecification';
 
 interface Props {
   openApiConfigureToggle: () => void;
@@ -239,6 +221,22 @@ export const OpenApiConfigure: FunctionComponent<Props> = (props) => {
   const configureRestOpenApiClientRecurse = (contextNode: IVisualizationNode) => {
     if (contextNode.getTitle() == 'rest-openapi' && contextNode.getId() == props.restOpenApiId) {
       console.log('Found rest-api, updating');
+
+      let currentDefinition = { parameters: {} };
+      if (isDefined(contextNode.getComponentSchema())) {
+        currentDefinition = contextNode.getComponentSchema()!.definition;
+      }
+
+      const newDefinition = {
+        ...currentDefinition,
+        parameters: {
+          ...currentDefinition.parameters,
+          host: hostName,
+          operationId: operationId,
+          specificationUri: specUrl,
+        },
+      };
+      contextNode.updateModel(newDefinition);
     } else {
       contextNode.getChildren()?.forEach((child) => {
         configureRestOpenApiClientRecurse(child);

--- a/packages/ui/src/components/OpenApi/Consumer/OpenApiSpecification.tsx
+++ b/packages/ui/src/components/OpenApi/Consumer/OpenApiSpecification.tsx
@@ -109,10 +109,7 @@ export const OpenApiSpecification: FunctionComponent<Props> = (props) => {
     setFiltered(filtered);
   }, [search, apicurioArtifacts]);
 
-  const handleTabClick = (
-    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
-    tabIndex: string | number,
-  ) => {
+  const handleTabClick = (_event: unknown, tabIndex: string | number) => {
     setActiveTabKey(tabIndex);
   };
 
@@ -181,12 +178,13 @@ export const OpenApiSpecification: FunctionComponent<Props> = (props) => {
   };
 
   useEffect(() => {
-    if (props.specificationUri !== '' && props.specificationUri.startsWith('http')) {
+    if (isDefined(props.specificationUri) && props.specificationUri.startsWith('http')) {
       updateDownloadUrl(props.specificationUri);
     }
 
     const apicurioRegistryUrl = settingsAdapter.getSettings().apicurioRegistryUrl;
 
+    // TODO: Place this URL in a config file.
     fetch(apicurioRegistryUrl + '/apis/registry/v2/search/artifacts', { method: 'GET', mode: 'cors' })
       .then((res) => res.json() as Promise<ApicurioArtifactSearchResult>)
       .then((apicurioArtifactSearchResult) => {
@@ -201,7 +199,7 @@ export const OpenApiSpecification: FunctionComponent<Props> = (props) => {
         setApicurioArtifacts(newApicurioArtifacts);
         setFiltered(newApicurioArtifacts);
       });
-  }, [isDownloadDisabled, isUploadDisabled]);
+  }, [isDownloadDisabled, isUploadDisabled, props.specificationUri, settingsAdapter]);
 
   return (
     <Tabs
@@ -271,7 +269,7 @@ export const OpenApiSpecification: FunctionComponent<Props> = (props) => {
                     <SearchInput
                       aria-label="Search Open API input"
                       placeholder="Find Open API by name"
-                      onChange={(event, value) => setSearch(value)}
+                      onChange={(_event, value) => setSearch(value)}
                     />
                   </ActionListItem>
                 </ActionList>


### PR DESCRIPTION
### Context
After finding the right `IVizNode`, this PR updates its parameters.

![image](https://github.com/user-attachments/assets/f53e6bfa-b47b-4447-9e2d-2d850de0bb07)


### Notes
When importing the OpenApi schema, `JSON` is supported while `YAML` looks like it's not.

#### This works
https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/petstore.json

#### This is not
https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/examples/v3.0/petstore.yaml

